### PR TITLE
WebUI: Update documentation and add "isPrivate" flag for 'properties' and 'info' API

### DIFF
--- a/WebUI-API-(qBittorrent-4.1).md
+++ b/WebUI-API-(qBittorrent-4.1).md
@@ -1242,7 +1242,7 @@ Name: `info`
 Parameter             | Type    | Description
 ----------------------|---------|------------
 `filter`  _optional_  | string  | Filter torrent list by state. Allowed state filters: `all`, `downloading`, `seeding`, `completed`, `paused`, `active`, `inactive`, `resumed`, `stalled`, `stalled_uploading`, `stalled_downloading`, `errored`
-`category` _optional_ | string  | Get torrents with the given category (empty string means "without category"; no "category" parameter means "any category" <- broken until [#11748](https://github.com/qbittorrent/qBittorrent/issues/11748) is resolved). Remember to URL-encode the category name. For example, `My category` becomes `My%20category`
+`category` _optional_ | string  | Get torrents with the given category (empty string means "without category"; no "category" parameter means "any category"). Remember to URL-encode the category name. For example, `My category` becomes `My%20category`
 `tag` _optional_ <sup>since 2.8.3</sup> | string  | Get torrents with the given tag (empty string means "without tag"; no "tag" parameter means "any tag". Remember to URL-encode the category name. For example, `My tag` becomes `My%20tag`
 `sort` _optional_     | string  | Sort torrents by given key. They can be sorted using any field of the response's JSON array (which are documented below) as the sort key.
 `reverse` _optional_  | bool    | Enable reverse sorting. Defaults to `false`

--- a/WebUI-API-(qBittorrent-4.1).md
+++ b/WebUI-API-(qBittorrent-4.1).md
@@ -1282,6 +1282,7 @@ Property             | Type    | Description
 `f_l_piece_prio`     | bool    | True if first last piece are prioritized
 `force_start`        | bool    | True if force start is enabled for this torrent
 `hash`               | string  | Torrent hash
+`isPrivate`          | bool    | True if torrent is from a private tracker (added in 5.0.0)
 `last_activity`      | integer | Last time (Unix Epoch) when a chunk was downloaded/uploaded
 `magnet_uri`         | string  | Magnet URI corresponding to this torrent
 `max_ratio`          | float   | Maximum share ratio until torrent is stopped from seeding/uploading
@@ -1360,7 +1361,8 @@ Example:
         "size":657457152,
         "state":"downloading",
         "super_seeding":false,
-        "upspeed":0
+        "upspeed":0,
+        "isPrivate":true
     },
     {
         another_torrent_info
@@ -1427,6 +1429,7 @@ Property                  | Type    | Description
 `total_size`              | integer | Torrent total size (bytes)
 `up_speed_avg`            | integer | Torrent average upload speed (bytes/second)
 `up_speed`                | integer | Torrent upload speed (bytes/second)
+`isPrivate`               | bool    | True if torrent is from a private tracker
 
 NB: `-1` is returned if the type of the property is integer but its value is not known.
 
@@ -1443,6 +1446,7 @@ Example:
     "dl_speed":0,
     "dl_speed_avg":9736015,
     "eta":8640000,
+    "isPrivate":true,
     "last_seen":1438430354,
     "nb_connections":3,
     "nb_connections_limit":250,


### PR DESCRIPTION
Closes [WebUI: Update documentation and add "isPrivate" flag for 'properties' and 'info' API](https://github.com/qbittorrent/qBittorrent/issues/20687)