### PR TITLE
Add missing inactiveSeedingTimeLimit parameter to section setShareLimits in WebUI API wiki

### DIFF
--- a/WebUI-API-(qBittorrent-4.1).md
+++ b/WebUI-API-(qBittorrent-4.1).md
@@ -2196,12 +2196,17 @@ Cookie: SID=your_sid
 Content-Type: application/x-www-form-urlencoded
 Content-Length: length
 
-hashes=8c212779b4abde7c6bc608063a0d008b7e40ce32|284b83c9c7935002391129fd97f43db5d7cc2ba0&ratioLimit=1.0&seedingTimeLimit=60
+hashes=8c212779b4abde7c6bc608063a0d008b7e40ce32|284b83c9c7935002391129fd97f43db5d7cc2ba0&ratioLimit=1.0&seedingTimeLimit=60&inactiveSeedingTimeLimit=-2
 ```
 
-`hashes` can contain multiple hashes separated by `|` or set to `all`
-`ratioLimit` is the max ratio the torrent should be seeded until. `-2` means the global limit should be used, `-1` means no limit.
-`seedingTimeLimit` is the max amount of time (minutes) the torrent should be seeded. `-2` means the global limit should be used, `-1` means no limit.
+**Parameters:**
+
+Property                      | Type    | Description
+------------------------------|---------|------------
+`hashes`                      | integer | The hashes of the torrents for which you want to set the share limits. Multiple hashes need to be seperated by `\|` or set to `all`.
+`ratioLimit`                  | integer | The maximum seeding ratio for the torrent. `-2` means the global limit should be used, `-1` means no limit.
+`seedingTimeLimit`            | integer | The maximum seeding time (minutes) for the torrent. `-2` means the global limit should be used, `-1` means no limit.
+`inactiveSeedingTimeLimit`    | integer | The maximum amount of time (minutes) the torrent is allowed to seed while being inactive. `-2` means the global limit should be used, `-1` means no limit.
 
 **Returns:**
 

--- a/WebUI-API-(qBittorrent-4.1).md
+++ b/WebUI-API-(qBittorrent-4.1).md
@@ -2203,7 +2203,7 @@ hashes=8c212779b4abde7c6bc608063a0d008b7e40ce32|284b83c9c7935002391129fd97f43db5
 
 Property                      | Type    | Description
 ------------------------------|---------|------------
-`hashes`                      | integer | The hashes of the torrents for which you want to set the share limits. Multiple hashes need to be seperated by `\|` or set to `all`.
+`hashes`                      | integer | The hashes of the torrents for which you want to set the share limits. Multiple hashes need to be separated by `\|` or set to `all`.
 `ratioLimit`                  | float   | The maximum seeding ratio for the torrent. `-2` means the global limit should be used, `-1` means no limit.
 `seedingTimeLimit`            | integer | The maximum seeding time (minutes) for the torrent. `-2` means the global limit should be used, `-1` means no limit.
 `inactiveSeedingTimeLimit`    | integer | The maximum amount of time (minutes) the torrent is allowed to seed while being inactive. `-2` means the global limit should be used, `-1` means no limit.

--- a/WebUI-API-(qBittorrent-4.1).md
+++ b/WebUI-API-(qBittorrent-4.1).md
@@ -2204,7 +2204,7 @@ hashes=8c212779b4abde7c6bc608063a0d008b7e40ce32|284b83c9c7935002391129fd97f43db5
 Property                      | Type    | Description
 ------------------------------|---------|------------
 `hashes`                      | integer | The hashes of the torrents for which you want to set the share limits. Multiple hashes need to be seperated by `\|` or set to `all`.
-`ratioLimit`                  | integer | The maximum seeding ratio for the torrent. `-2` means the global limit should be used, `-1` means no limit.
+`ratioLimit`                  | float   | The maximum seeding ratio for the torrent. `-2` means the global limit should be used, `-1` means no limit.
 `seedingTimeLimit`            | integer | The maximum seeding time (minutes) for the torrent. `-2` means the global limit should be used, `-1` means no limit.
 `inactiveSeedingTimeLimit`    | integer | The maximum amount of time (minutes) the torrent is allowed to seed while being inactive. `-2` means the global limit should be used, `-1` means no limit.
 

--- a/WebUI-API-(qBittorrent-4.1).md
+++ b/WebUI-API-(qBittorrent-4.1).md
@@ -2212,7 +2212,8 @@ Property                      | Type    | Description
 
 HTTP Status Code                  | Scenario
 ----------------------------------|---------------------
-200                               | All scenarios
+200                               | All other scenarios
+400                               | Bad Request, e.g. missing parameter
 
 ## Get torrent upload limit ##
 


### PR DESCRIPTION
Updates the ['Set share limit'](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#set-torrent-share-limit) section in the WebUI API wiki:

Changes:
- Adds the `inactiveSeedingTimeLimit` parameter to the WebUI API wiki page, which was missing before
- organizes the parameters in a table for better readability
- revises parameter descriptions slightly to be more concise
- mentions missing parameter scenario for response error code 400 Bad Request

The `inactiveSeedingTimeLimit` parameter was added in v4.6.0, but not added to the wiki, which meant that previously functional requests would now return error code 400 because of the missing parameter.

Addresses issues [#20787](https://github.com/qbittorrent/qBittorrent/issues/20787) and  [#20110](https://github.com/qbittorrent/qBittorrent/issues/20110) in the [main qBittorent repo](https://github.com/qbittorrent/qBittorrent).