### PR TITLE
Add instructions for Flatpak

### DIFF
--- a/Frequently-Asked-Questions.mediawiki
+++ b/Frequently-Asked-Questions.mediawiki
@@ -81,15 +81,15 @@ GNU/Linux:
 ** <code>~/.local/share/data/qBittorrent/</code> (in case legacy data directory was used)
 
 Linux/Flatpak:
-* preferences
+* preferences:
 ** <code>~/.var/app/org.qbittorrent.qBittorrent/config/qBittorrent/</code>
-* .torrent files, logs, etc (This is the standard [https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html XDG] data folder):
+* .torrent files, logs, etc:
 ** <code>~/.var/app/org.qbittorrent.qBittorrent/data/qBittorrent/</code>
 
 Linux/SnapStore:
 * preferences:
 ** <code>~/snap/qbittorrent-arnatious/current/.config/qBittorrent/</code>
-* .torrent files, logs, etc (This is the standard [https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html XDG] data folder):
+* .torrent files, logs, etc:
 ** <code>~/snap/qbittorrent-arnatious/current/.local/share/data/qBittorrent/</code>
 
 OS X:

--- a/Frequently-Asked-Questions.mediawiki
+++ b/Frequently-Asked-Questions.mediawiki
@@ -80,6 +80,12 @@ GNU/Linux:
 ** <code>~/.local/share/qBittorrent/</code>
 ** <code>~/.local/share/data/qBittorrent/</code> (in case legacy data directory was used)
 
+Linux/Flatpak:
+* preferences
+** <code>~/.var/app/org.qbittorrent.qBittorrent/config/qBittorrent/</code>
+* .torrent files, logs, etc (This is the standard [https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html XDG] data folder):
+** <code>~/.var/app/org.qbittorrent.qBittorrent/data/qBittorrent/</code>
+
 Linux/SnapStore:
 * preferences:
 ** <code>~/snap/qbittorrent-arnatious/current/.config/qBittorrent/</code>


### PR DESCRIPTION
I have added instructions for where the qBittorrent Flatpak stores its settings. The Flatpak version is quite popular, and I just switched to it myself, so I thought it was worth adding this info to the FAQ.