### PR TITLE
Make redirected link to the list of unofficial search plugins direct

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -28,7 +28,7 @@ The wiki source code is hosted at https://github.com/qbittorrent/wiki and is acc
 
 ### Search plugins
 
-- [List of unofficial search plugins](https://github.com/qbittorrent/qBittorrent/wiki/Unofficial-search-plugins)
+- [List of unofficial search plugins](https://github.com/qbittorrent/search-plugins/wiki/Unofficial-search-plugins)
 
 ### Themes
 

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -22,7 +22,7 @@
 
 ### Search plugins
 
-- [List of unofficial search plugins](https://github.com/qbittorrent/qBittorrent/wiki/Unofficial-search-plugins)
+- [List of unofficial search plugins](https://github.com/qbittorrent/search-plugins/wiki/Unofficial-search-plugins)
 
 ### Themes
 


### PR DESCRIPTION
This change reduces the number of clicks, even if minimal. Keeping the redirect to avoid dead incoming links.