### PR TITLE
Update Compilation-Alpine-Linux.md

### DIFF
--- a/Compilation-Alpine-Linux.md
+++ b/Compilation-Alpine-Linux.md
@@ -37,7 +37,7 @@ apk add icu-dev openssl-dev qt6-qtbase-dev qt6-qttools-dev zlib-dev
 > [!TIP]
 > This command should provide the latest non beta release info from Github
 >
-> - `curl -sL https://api.github.com/repos/boostorg/boost/releases | jq -r '.[].name | select(contains("beta") | not)' | head -n 1'`
+> - `curl -sL https://api.github.com/repos/boostorg/boost/releases | jq -r 'map(.name | select(test("boost-[\\d\\.]+$"))) | first'`
 >
 > You can view all the tags for the boost Github repository here:
 >


### PR DESCRIPTION
fixed typo preventing admonition being rendered.

fix boost command. should have used `[]` instead of `[0]`. worked fine when `1.86.0` was `[0]` but now `1.87.0.beta1` was `[0]` the result was blank. so now it shows all non beta tags and uses `head -n1` to get most recent tag first.