### PR TITLE
Added some additional notes on multipart/form-data boundaries

### DIFF
--- a/WebUI-API-(qBittorrent-4.1).md
+++ b/WebUI-API-(qBittorrent-4.1).md
@@ -1921,6 +1921,25 @@ HTTP Status Code                  | Scenario
 415                               | Torrent file is not valid
 200                               | All other scenarios
 
+### Notes on boundaries ###
+
+Also, be aware that multipart/form-data boundaries in the POST body are preceeded by two hyphens, and the end of the body is closed by two hyphens added to the end of the boundary string.
+For example, if you use a random string and your header has:
+
+```
+Content-Type: multipart/form-data; boundary=--AqhE2AFEJbRxE4xx
+```
+
+Your POST body would look like this:
+
+```
+----AqhE2AFEJbRxE4xx
+Content-Disposition: form-data; name="urls"
+
+https://torcache.net/torrent/3B1A1469C180F447B77021074DBBCCAEF62611E7.torrent
+----AqhE2AFEJbRxE4xx--
+```
+
 ## Add trackers to torrent ##
 
 Requires knowing the torrent hash. You can get it from [torrent list](#get-torrent-list).


### PR DESCRIPTION
While I was working on some automation via the API, got stuck on trying to add things via the multipart/form-data POST body, and eventually figured out the boundaries in the example body have two more hyphens than the header. This is correct, but with the large number of hyphens in the example, it's easy to overlook this small difference.

`---------------------------6688794727912`
vs
`-----------------------------6688794727912`

This PR adds some notes to call out this difference.