### PR TITLE
Add links to the WebAPI v5.x

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -48,7 +48,8 @@ The wiki source code is hosted at https://github.com/qbittorrent/wiki and is acc
 
 | State                                                                                               | Version                     |
 | --------------------------------------------------------------------------------------------------- | --------------------------- |
-| [Current](<https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)>)            | qBittorrent ≥ v4.1          |
+| [Current](<https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)>)            | qBittorrent >= 5.0          |
+| [Previous](<https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)>)           | qBittorrent v4.1.0 - v4.6.x |
 | [Previous](<https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-v3.2.0-v4.0.4)>) | qBittorrent v3.2.0 - v4.0.x |
 | [Obsolete](<https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-v3.1.x)>)        | qBittorrent < v3.2.0        |
 

--- a/WebUI-API-(qBittorrent-4.1).md
+++ b/WebUI-API-(qBittorrent-4.1).md
@@ -1,4 +1,4 @@
-This WebUI API documentation applies to qBittorrent v4.1+. For other WebUI API versions, visit [WebUI API](https://github.com/qbittorrent/qBittorrent/wiki#WebUI-API).
+This WebUI API documentation applies to qBittorrent v4.1-v4.6.x. For other WebUI API versions, visit [WebUI API](https://github.com/qbittorrent/qBittorrent/wiki#WebUI-API).
 
 # Table of Contents #
 

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -42,7 +42,8 @@
 
 | State                                                                                               | Version                     |
 | --------------------------------------------------------------------------------------------------- | --------------------------- |
-| [Current](<https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)>)            | qBittorrent ≥ v4.1          |
+| [Current](<https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-5.0)>)            | qBittorrent >= 5.0          |
+| [Previous](<https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)>)           | qBittorrent v4.1.0 - v4.6.x |
 | [Previous](<https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-v3.2.0-v4.0.4)>) | qBittorrent v3.2.0 - v4.0.x |
 | [Obsolete](<https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-v3.1.x)>)        | qBittorrent < v3.2.0        |
 


### PR DESCRIPTION
I was not aware there was a new API version because it was not linked in the wiki.