### PR TITLE
Update QT6 in Compilation-Debian,-Ubuntu,-and-derivatives.md

### DIFF
--- a/Compilation-Debian,-Ubuntu,-and-derivatives.md
+++ b/Compilation-Debian,-Ubuntu,-and-derivatives.md
@@ -21,8 +21,8 @@ sudo apt install build-essential cmake git ninja-build pkg-config libboost-dev l
 
 qBittorrent uses the Qt framework as the basis for its GUI.
 
-- qBittorrent 4.4.x requires at least Qt 5.15.2.
-- At the time of writing, the current `master` branch requires at least Qt 5.15.2.
+- qBittorrent 5.1.x requires at least Qt 6.5.0.
+- At the time of writing, the current `master` branch requires at least Qt 6.6.0.
 
 Many distributions, in particular Debian, Ubuntu (especially LTS releases), and their derivatives don't provide up-to-date Qt packages in their repositories or are very slow in updating them.
 In such cases, you must get them from somewhere else, such as the official installer from the [Qt website](https://www.qt.io/download-qt-installer) (unfortunately, this method requires the creation of an account, but you can just use a throwaway email), or a PPA you trust in the case of Ubuntu and other distributions that support that installation method.
@@ -30,7 +30,7 @@ In such cases, you must get them from somewhere else, such as the official insta
 For Debian and Ubuntu versions that include sufficiently up-to-date Qt packages, you can just install the following packages from the official repositories:
 
 ```bash
-sudo apt install --no-install-recommends qtbase5-dev qttools5-dev libqt5svg5-dev
+sudo apt install --no-install-recommends qt6-base-dev qt6-base-private-dev qt6-tools-dev qt6-svg-dev
 ```
 
 ## libtorrent
@@ -53,8 +53,9 @@ git clone --recurse-submodules https://github.com/arvidn/libtorrent.git
 cd libtorrent
 git checkout RC_2_0 # or a 2.0.x tag
 cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr/local
-cmake --build build
-sudo cmake --install build
+cd build
+ninja
+sudo ninja install
 ```
 
 The install step will install libtorrent to the chosen prefix (`/usr/local`, in this case), and generate an `install_manifest.txt` file in the build folder that can later be used to uninstall all installed files with `sudo xargs rm < install_manifest.txt`.


### PR DESCRIPTION
Resolves #2 , qbittorrent/qBittorrent#22824 , qbittorrent/qBittorrent#21131, and half of qbittorrent/qBittorrent#21603 / #15

* Update qt6 packages
* libtorrent build uses ninja directly not cmake
* Addressed comment in #2

# Testing

All-in-one Dockerfile builds a GUI successfully. Debian version GUI starts successfully. 

Works for Debian Sid/Testing and Ubuntu Plucky (25.04)

```
FROM debian:sid
# FROM debian:bookworm
# FROM ubuntu:plucky

ADD libtorrent /work/libtorrent
ADD qBittorrent /work/qBittorrent

# Common build deps
RUN set -e -x && \
    echo 'Acquire::http::Proxy "http://192.168.66.11:3142";' > /etc/apt/apt.conf.d/99proxy && \
    apt-get update && \
    apt-get -y install build-essential cmake git ninja-build 
    # pkg-config 

# libtorrent
RUN set -e -x && \
    apt-get -y install libboost-dev libssl-dev 
RUN set -e -x && \
    cd /work/libtorrent && \
    cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr/local -G Ninja && \
    cd build && \
    ninja && \
    ninja install

# qbittorrent
RUN set -e -x && \
    apt-get -y install --no-install-recommends  qt6-tools-dev qt6-base-dev qt6-base-private-dev qt6-svg-dev zlib1g-dev
    # libtorrent-rasterbar-dev
RUN set -e -x && \
    cd /work/qBittorrent && \
    cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release -DWEBUI=ON -DGUI=ON -DTESTING=ON && \
    cmake --build build
```