### PR TITLE
Updated qBittorrent systemd file to add a timeout

### DIFF
--- a/Running-qBittorrent-without-X-server-(WebUI-only,-systemd-service-set-up,-Ubuntu-15.04-or-newer).md
+++ b/Running-qBittorrent-without-X-server-(WebUI-only,-systemd-service-set-up,-Ubuntu-15.04-or-newer).md
@@ -119,6 +119,8 @@ ExecStart=/usr/bin/qbittorrent-nox
 # uncomment this to use "Network interface" and/or "Optional IP address to bind to" options
 # without this binding will fail and qBittorrent's traffic will go through the default route
 # AmbientCapabilities=CAP_NET_RAW
+# uncomment this if your qBittorrent instance is being killed by systemd before it can clean up (like announcing to trackers stop)
+# TimeoutStopSec=1800
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Added in a timeout to the systemd section of qBittorrent that would kill the qBittorrent process before it could send a stop message to all trackers (if you have a lot of torrents, it would kill them all before you could tell that tracker to stop + possibly any other actions that occur after this).

See [here](https://github.com/qbittorrent/qBittorrent/issues/22956)