### PR TITLE
rename pausedUP/DL to stoppedUP/DL statuses WebUI-API-(qBittorrent-5.0).md

### DIFF
--- a/WebUI-API-(qBittorrent-5.0).md
+++ b/WebUI-API-(qBittorrent-5.0).md
@@ -989,7 +989,7 @@ Example:
     {
         "8c212779b4abde7c6bc608063a0d008b7e40ce32":
         {
-            "state":"pausedUP"
+            "state":"stoppedUP"
         }
     }
 }
@@ -1287,7 +1287,7 @@ Value         | Description
 `error`       | Some error occurred, applies to paused torrents
 `missingFiles`| Torrent data files is missing
 `uploading`   | Torrent is being seeded and data is being transferred
-`pausedUP`    | Torrent is paused and has finished downloading
+`stoppedUP`    | Torrent is paused and has finished downloading
 `queuedUP`    | Queuing is enabled and torrent is queued for upload
 `stalledUP`   | Torrent is being seeded, but no connection were made
 `checkingUP`  | Torrent has finished downloading and is being checked
@@ -1295,7 +1295,7 @@ Value         | Description
 `allocating`  | Torrent is allocating disk space for download
 `downloading` | Torrent is being downloaded and data is being transferred
 `metaDL`      | Torrent has just started downloading and is fetching metadata
-`pausedDL`    | Torrent is paused and has NOT finished downloading
+`stoppedDL`    | Torrent is paused and has NOT finished downloading
 `queuedDL`    | Queuing is enabled and torrent is queued for download
 `stalledDL`   | Torrent is being downloaded, but no connection were made
 `checkingDL`  | Same as checkingUP, but torrent has NOT finished downloading


### PR DESCRIPTION
Some references in the latest API docs weren't updated.

I only updated the statuses that I knew didn't exist anymore.
There are other references to "paused" in the docs, but I didn't go thru the code or test the API to verify whether they were also renamed to "stopped" in the latest version.  So it didn't update _every_ reference to "paused".