### PR TITLE
Update WebUI-API-(qBittorrent-5.0).md

### DIFF
--- a/WebUI-API-(qBittorrent-5.0).md
+++ b/WebUI-API-(qBittorrent-5.0).md
@@ -1916,8 +1916,8 @@ Name: `editTracker`
 Parameter                         | Type    | Description
 ----------------------------------|---------|------------
 `hash`                            | string  | The hash of the torrent
-`origUrl`                         | string  | The tracker URL you want to edit
-`newUrl`                          | string  | The new URL to replace the `origUrl`
+`url`                             | string  | The tracker URL you want to edit
+`newUrl`                          | string  | The new URL to replace the `url`
 
 **Returns:**
 
@@ -1926,7 +1926,7 @@ HTTP Status Code                  | Scenario
 400                               | `newUrl` is not a valid URL
 404                               | Torrent hash was not found
 409                               | `newUrl` already exists for the torrent
-409                               | `origUrl` was not found
+409                               | `url` was not found
 200                               | All other scenarios
 
 ## Remove trackers ##


### PR DESCRIPTION
Rename the origUrl parameter to url as done in the [6ef9db89f9cd3ae1bdc64396982a9ca84190d1db](https://github.com/qbittorrent/qBittorrent/commit/6ef9db89f9cd3ae1bdc64396982a9ca84190d1db) commit.

I don’t know if I did it the right way, or if I missed other changes, but this one seems particulary critical since it break setups, I had to guess how I should do it to fix my scripts, I guess other people can have the same problem.