### PR TITLE
updated list of unofficial web api

### DIFF
--- a/List-of-unofficial-WebAPI-clients.md
+++ b/List-of-unofficial-WebAPI-clients.md
@@ -18,11 +18,11 @@ If you know of more, feel free to add a link to the repository along with a shor
 
 - https://github.com/Conan1996-2/qBitorrent-WebUI-API
 
+VB .NET code to access qBitorrent's WebAPI
+
 - https://github.com/taylorcox75/qRemote
 
     iOS app for managing qBittorrent remotely via its WebAPI, available (free) in App Store
-
-    VB .NET code to access qBitorrent's WebAPI
 
 - https://github.com/fedarovich/qbittorrent-cli
 

--- a/List-of-unofficial-WebAPI-clients.md
+++ b/List-of-unofficial-WebAPI-clients.md
@@ -23,6 +23,13 @@ If you know of more, feel free to add a link to the repository along with a shor
 - https://github.com/taylorcox75/qRemote
 
     iOS app for managing qBittorrent remotely via its WebAPI, available (free) in App Store
+- https://github.com/taylorcox75/qRemote
+
+    iOS app for managing qBittorrent remotely via its WebAPI, available (free) in App Store
+    
+- https://github.com/Conan1996-2/qBitorrent-WebUI-API
+
+    VB .NET code to access qBitorrent's WebAPI
 
 - https://github.com/fedarovich/qbittorrent-cli
 

--- a/List-of-unofficial-WebAPI-clients.md
+++ b/List-of-unofficial-WebAPI-clients.md
@@ -23,13 +23,6 @@ If you know of more, feel free to add a link to the repository along with a shor
 - https://github.com/taylorcox75/qRemote
 
     iOS app for managing qBittorrent remotely via its WebAPI, available (free) in App Store
-- https://github.com/taylorcox75/qRemote
-
-    iOS app for managing qBittorrent remotely via its WebAPI, available (free) in App Store
-    
-- https://github.com/Conan1996-2/qBitorrent-WebUI-API
-
-    VB .NET code to access qBitorrent's WebAPI
 
 - https://github.com/fedarovich/qbittorrent-cli
 

--- a/List-of-unofficial-WebAPI-clients.md
+++ b/List-of-unofficial-WebAPI-clients.md
@@ -18,7 +18,7 @@ If you know of more, feel free to add a link to the repository along with a shor
 
 - https://github.com/Conan1996-2/qBitorrent-WebUI-API
 
-VB .NET code to access qBitorrent's WebAPI
+    VB .NET code to access qBitorrent's WebAPI
 
 - https://github.com/taylorcox75/qRemote
 

--- a/List-of-unofficial-WebAPI-clients.md
+++ b/List-of-unofficial-WebAPI-clients.md
@@ -18,6 +18,9 @@ If you know of more, feel free to add a link to the repository along with a shor
 
 - https://github.com/Conan1996-2/qBitorrent-WebUI-API
 
+    iOS app for managing qBittorrent remotely via its WebAPI, available (free) in App Store
+- https://github.com/taylorcox75/qRemote
+
     VB .NET code to access qBitorrent's WebAPI
 
 - https://github.com/fedarovich/qbittorrent-cli

--- a/List-of-unofficial-WebAPI-clients.md
+++ b/List-of-unofficial-WebAPI-clients.md
@@ -18,8 +18,9 @@ If you know of more, feel free to add a link to the repository along with a shor
 
 - https://github.com/Conan1996-2/qBitorrent-WebUI-API
 
-    iOS app for managing qBittorrent remotely via its WebAPI, available (free) in App Store
 - https://github.com/taylorcox75/qRemote
+
+    iOS app for managing qBittorrent remotely via its WebAPI, available (free) in App Store
 
     VB .NET code to access qBitorrent's WebAPI
 


### PR DESCRIPTION
This pull request adds a new entry to the `List-of-unofficial-WebAPI-clients.md` file, providing information about an iOS app for managing qBittorrent remotely via its WebAPI.

New client listing:

* Added a link to the `qRemote` iOS app, including a short description and information about its availability in the App Store.