### PR TITLE
Fix links that redirect to raw markdown

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -12,7 +12,7 @@ The wiki source code is hosted at https://github.com/qbittorrent/wiki and is acc
 - [How to use qBittorrent as a tracker](https://github.com/qbittorrent/qBittorrent/wiki/How-to-use-qBittorrent-as-a-tracker)
 - [How to use portable mode](https://github.com/qbittorrent/qBittorrent/wiki/How-to-use-portable-mode)
 - [Anonymous mode](https://github.com/qbittorrent/qBittorrent/wiki/Anonymous-Mode)
-- [How to bind your vpn to prevent ip leaks](https://github.com/qbittorrent/qBittorrent/wiki/How-to-bind-your-vpn-to-prevent-ip-leaks.md)
+- [How to bind your vpn to prevent ip leaks](https://github.com/qbittorrent/qBittorrent/wiki/How-to-bind-your-vpn-to-prevent-ip-leaks)
 
 ### Troubleshooting
 

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -6,7 +6,7 @@
 - [How to use qBittorrent as a tracker](https://github.com/qbittorrent/qBittorrent/wiki/How-to-use-qBittorrent-as-a-tracker)
 - [How to use portable mode](https://github.com/qbittorrent/qBittorrent/wiki/How-to-use-portable-mode)
 - [Anonymous mode](https://github.com/qbittorrent/qBittorrent/wiki/Anonymous-Mode)
-- [How to bind your vpn to prevent ip leaks](https://github.com/qbittorrent/qBittorrent/wiki/How-to-bind-your-vpn-to-prevent-ip-leaks.md)
+- [How to bind your vpn to prevent ip leaks](https://github.com/qbittorrent/qBittorrent/wiki/How-to-bind-your-vpn-to-prevent-ip-leaks)
 
 ### Troubleshooting
 


### PR DESCRIPTION
Leaving the `.md` extension inadvertently forces GitHub's servers to force a redirect to the [raw markdown content](https://raw.githubusercontent.com/wiki/qbittorrent/qBittorrent/How-to-bind-your-vpn-to-prevent-ip-leaks.md). I did a quick search for other instances of the `.md` extension on links to the Wiki, but as far as I can tell, only the VPN page had this issue.